### PR TITLE
chore: fix runtime issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 project(icm20948 VERSION 0.1.0 LANGUAGES CXX)
 
-add_compile_options(-Wall -Wextra)
+add_compile_options(-Wall -Wextra -fstack-protector)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/util/ ${CMAKE_CURRENT_SOURCE_DIR}/include)
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/ ${CMAKE_CURRENT_SOURCE_DIR}/util/)

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -4,421 +4,406 @@
 #define IMU_ADDRESS 0x68
 
 enum class CommMode { SPI, I2C };
-CommMode currentMode = CommMode::I2C; // Default to I2C
+CommMode currentMode = CommMode::I2C;  // Default to I2C
 
 ICM_20948_I2C icm_i2c;
-ICM_20948_SPI icm_spi(ICM_20948_SPI_DEFAULT_FREQ, 8);
+// ICM_20948_SPI icm_spi(2000000, 8);
+ICM_20948_SPI icm_spi;
 
 // Functions used to print the IMU data on stdout
 void printPaddedInt16b(int16_t val);
 void printRawAGMT(ICM_20948_AGMT_t agmt);
 void printFormattedFloat(float val, uint8_t leading);
-void printScaledAGMT(ICM_20948_I2C *sensor);
-void printScaledAGMT(ICM_20948_SPI *sensor);
+void printScaledAGMT(ICM_20948_I2C* sensor);
+void printScaledAGMT(ICM_20948_SPI* sensor);
 
-int main(int argc, char **argv) {
-  bool initialized = false;
+int main(int argc, char** argv) {
+    bool initialized = false;
 
-  // Parse command-line arguments to set the mode (I2C/SPI)
-  for (int i = 1; i < argc; i++) {
-    if (strcmp(argv[i], "--spi") == 0) {
-      currentMode = CommMode::SPI;
-    } else if (strcmp(argv[i], "--i2c") == 0) {
-      currentMode = CommMode::I2C;
-    }
-  }
-
-  if (currentMode == CommMode::SPI) {
-    // SPI initialization
-    while (!initialized) {
-      icm_spi.begin("/dev/spidev2.0");
-      std::cout << "Initialization of the sensor over SPI returned: "
-                << icm_spi.statusString() << std::endl;
-      if (icm_spi.status != ICM_20948_Stat_Ok) {
-        printf("Trying again...\r\n");
-        delay(500);
-      } else {
-        initialized = true;
-      }
-    }
-  } else {
-    // I2C initialization
-    while (!initialized) {
-      icm_i2c.begin(I2C_BUS, IMU_ADDRESS);
-      std::cout << "Initialization of the sensor over I2C returned: "
-                << icm_i2c.statusString() << std::endl;
-      if (icm_i2c.status != ICM_20948_Stat_Ok) {
-        printf("Trying again...\r\n");
-        delay(500);
-      } else {
-        initialized = true;
-      }
-    }
-  }
-
-  printf("Device connected!\r\n");
-
-  if (currentMode == CommMode::SPI) {
-    icm_spi.swReset();
-    if (icm_spi.status != ICM_20948_Stat_Ok) {
-      printf("Software Reset returned: ");
-      printf("%s\r\n", icm_spi.statusString());
-    }
-    delay(250);
-
-    // Now wake the sensor up
-    icm_spi.sleep(false);
-    icm_spi.lowPower(false);
-
-    // The next few configuration functions accept a bit-mask of sensors for
-    // which the settings should be applied.
-
-    // Set Gyro and Accelerometer to a particular sample mode
-    // options: ICM_20948_Sample_Mode_Continuous
-    //          ICM_20948_Sample_Mode_Cycled
-    icm_spi.setSampleMode((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr),
-                          ICM_20948_Sample_Mode_Continuous);
-    if (icm_spi.status != ICM_20948_Stat_Ok) {
-      printf("setSampleMode returned: ");
-      printf("%s\r\n", icm_spi.statusString());
-    }
-    // Set full scale ranges for both acc and gyr
-    ICM_20948_fss_t myFSS; // This uses a "Full Scale Settings" structure that
-                           // can contain values for all configurable sensors
-
-    myFSS.a = gpm2; // (ICM_20948_ACCEL_CONFIG_FS_SEL_e)
-                    // gpm2
-                    // gpm4
-                    // gpm8
-                    // gpm16
-
-    myFSS.g = dps1000; // (ICM_20948_GYRO_CONFIG_1_FS_SEL_e)
-                       // dps250
-                       // dps500
-                       // dps1000
-                       // dps2000
-
-    icm_spi.setFullScale((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr),
-                         myFSS);
-    if (icm_spi.status != ICM_20948_Stat_Ok) {
-      printf("setFullScale returned: ");
-      printf("%s\r\n", icm_spi.statusString());
+    // Parse command-line arguments to set the mode (I2C/SPI)
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--spi") == 0) {
+            currentMode = CommMode::SPI;
+        } else if (strcmp(argv[i], "--i2c") == 0) {
+            currentMode = CommMode::I2C;
+        }
     }
 
-    // Set up Digital Low-Pass Filter configuration
-    ICM_20948_dlpcfg_t myDLPcfg; // Similar to FSS, this uses a configuration
-                                 // structure for the desired sensors
-    myDLPcfg.a =
-        acc_d473bw_n499bw; // (ICM_20948_ACCEL_CONFIG_DLPCFG_e)
-                           // acc_d246bw_n265bw      - means 3db bandwidth is
-                           // 246 hz and nyquist bandwidth is 265 hz
-                           // acc_d111bw4_n136bw acc_d50bw4_n68bw8
-                           // acc_d23bw9_n34bw4 acc_d11bw5_n17bw acc_d5bw7_n8bw3
-                           // - means 3 db bandwidth is 5.7 hz and nyquist
-                           // bandwidth is 8.3 hz acc_d473bw_n499bw
-
-    myDLPcfg.g = gyr_d361bw4_n376bw5; // (ICM_20948_GYRO_CONFIG_1_DLPCFG_e)
-                                      // gyr_d196bw6_n229bw8
-                                      // gyr_d151bw8_n187bw6
-                                      // gyr_d119bw5_n154bw3
-                                      // gyr_d51bw2_n73bw3
-                                      // gyr_d23bw9_n35bw9
-                                      // gyr_d11bw6_n17bw8
-                                      // gyr_d5bw7_n8bw9
-                                      // gyr_d361bw4_n376bw5
-
-    icm_spi.setDLPFcfg((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr),
-                       myDLPcfg);
-    if (icm_spi.status != ICM_20948_Stat_Ok) {
-      printf("setDLPcfg returned: ");
-      printf("%s\r\n", icm_spi.statusString());
+    if (currentMode == CommMode::SPI) {
+        // SPI initialization
+        while (!initialized) {
+            icm_spi.begin("/dev/spidev2.0", 2000000);
+            std::cout << "Initialization of the sensor over SPI returned: " << icm_spi.statusString() << std::endl;
+            if (icm_spi.status != ICM_20948_Stat_Ok) {
+                printf("Trying again...\r\n");
+                delay(500);
+            } else {
+                initialized = true;
+            }
+        }
+    } else {
+        // I2C initialization
+        while (!initialized) {
+            icm_i2c.begin(I2C_BUS, IMU_ADDRESS);
+            std::cout << "Initialization of the sensor over I2C returned: " << icm_i2c.statusString() << std::endl;
+            if (icm_i2c.status != ICM_20948_Stat_Ok) {
+                printf("Trying again...\r\n");
+                delay(500);
+            } else {
+                initialized = true;
+            }
+        }
     }
 
-    // Choose whether or not to use DLPF
-    // Here we're also showing another way to access the status values, and that
-    // it is OK to supply individual sensor masks to these functions
-    ICM_20948_Status_e accDLPEnableStat =
-        icm_spi.enableDLPF(ICM_20948_Internal_Acc, false);
-    ICM_20948_Status_e gyrDLPEnableStat =
-        icm_spi.enableDLPF(ICM_20948_Internal_Gyr, false);
-    printf("Enable DLPF for Accelerometer returned: ");
-    printf("%s\r\n", icm_spi.statusString(accDLPEnableStat));
-    printf("Enable DLPF for Gyroscope returned: ");
-    printf("%s\r\n", icm_spi.statusString(gyrDLPEnableStat));
+    printf("Device connected!\r\n");
 
-    printf("Configuration complete!\r\n");
+    if (currentMode == CommMode::SPI) {
+        icm_spi.swReset();
+        if (icm_spi.status != ICM_20948_Stat_Ok) {
+            printf("Software Reset returned: ");
+            printf("%s\r\n", icm_spi.statusString());
+        }
+        delay(250);
 
-    while (1) {
-      if (icm_spi.dataReady()) {
-        auto start = std::chrono::system_clock::now();
-        icm_spi
-            .getAGMT(); // The values are only updated when you call 'getAGMT'
-        auto end = std::chrono::system_clock::now();
-        std::chrono::duration<double> elapsed = end - start;
-        printf(" Hz: %f", 1 / elapsed.count());
-        printf("\r\n");
+        // Now wake the sensor up
+        icm_spi.sleep(false);
+        icm_spi.lowPower(false);
 
-        // printRawAGMT( icm_spi.agmt ); // Uncomment this to see the raw
-        // values, taken directly from the agmt structure
-        printScaledAGMT(&icm_spi); // This function takes into account the scale
-                                   // settings from when the measurement was
-                                   // made to calculate the values with units
-        delay(10);
-      } else {
-        printf("Waiting for data\r\n");
-        delay(500);
-      }
+        // The next few configuration functions accept a bit-mask of sensors for
+        // which the settings should be applied.
+
+        // Set Gyro and Accelerometer to a particular sample mode
+        // options: ICM_20948_Sample_Mode_Continuous
+        //          ICM_20948_Sample_Mode_Cycled
+        icm_spi.setSampleMode((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr), ICM_20948_Sample_Mode_Continuous);
+        if (icm_spi.status != ICM_20948_Stat_Ok) {
+            printf("setSampleMode returned: ");
+            printf("%s\r\n", icm_spi.statusString());
+        }
+        // Set full scale ranges for both acc and gyr
+        ICM_20948_fss_t myFSS;  // This uses a "Full Scale Settings" structure that
+                                // can contain values for all configurable sensors
+
+        myFSS.a = gpm2;  // (ICM_20948_ACCEL_CONFIG_FS_SEL_e)
+                         // gpm2
+                         // gpm4
+                         // gpm8
+                         // gpm16
+
+        myFSS.g = dps1000;  // (ICM_20948_GYRO_CONFIG_1_FS_SEL_e)
+                            // dps250
+                            // dps500
+                            // dps1000
+                            // dps2000
+
+        icm_spi.setFullScale((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr), myFSS);
+        if (icm_spi.status != ICM_20948_Stat_Ok) {
+            printf("setFullScale returned: ");
+            printf("%s\r\n", icm_spi.statusString());
+        }
+
+        // Set up Digital Low-Pass Filter configuration
+        ICM_20948_dlpcfg_t myDLPcfg;     // Similar to FSS, this uses a configuration
+                                         // structure for the desired sensors
+        myDLPcfg.a = acc_d473bw_n499bw;  // (ICM_20948_ACCEL_CONFIG_DLPCFG_e)
+                                         // acc_d246bw_n265bw      - means 3db bandwidth is
+                                         // 246 hz and nyquist bandwidth is 265 hz
+                                         // acc_d111bw4_n136bw acc_d50bw4_n68bw8
+                                         // acc_d23bw9_n34bw4 acc_d11bw5_n17bw acc_d5bw7_n8bw3
+                                         // - means 3 db bandwidth is 5.7 hz and nyquist
+                                         // bandwidth is 8.3 hz acc_d473bw_n499bw
+
+        myDLPcfg.g = gyr_d361bw4_n376bw5;  // (ICM_20948_GYRO_CONFIG_1_DLPCFG_e)
+                                           // gyr_d196bw6_n229bw8
+                                           // gyr_d151bw8_n187bw6
+                                           // gyr_d119bw5_n154bw3
+                                           // gyr_d51bw2_n73bw3
+                                           // gyr_d23bw9_n35bw9
+                                           // gyr_d11bw6_n17bw8
+                                           // gyr_d5bw7_n8bw9
+                                           // gyr_d361bw4_n376bw5
+
+        icm_spi.setDLPFcfg((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr), myDLPcfg);
+        if (icm_spi.status != ICM_20948_Stat_Ok) {
+            printf("setDLPcfg returned: ");
+            printf("%s\r\n", icm_spi.statusString());
+        }
+
+        // Choose whether or not to use DLPF
+        // Here we're also showing another way to access the status values, and that
+        // it is OK to supply individual sensor masks to these functions
+        ICM_20948_Status_e accDLPEnableStat = icm_spi.enableDLPF(ICM_20948_Internal_Acc, false);
+        ICM_20948_Status_e gyrDLPEnableStat = icm_spi.enableDLPF(ICM_20948_Internal_Gyr, false);
+        printf("Enable DLPF for Accelerometer returned: ");
+        printf("%s\r\n", icm_spi.statusString(accDLPEnableStat));
+        printf("Enable DLPF for Gyroscope returned: ");
+        printf("%s\r\n", icm_spi.statusString(gyrDLPEnableStat));
+
+        printf("Configuration complete!\r\n");
+
+        while (1) {
+            if (icm_spi.dataReady()) {
+                auto start = std::chrono::system_clock::now();
+                icm_spi.getAGMT();  // The values are only updated when you call 'getAGMT'
+                auto end = std::chrono::system_clock::now();
+                std::chrono::duration<double> elapsed = end - start;
+                printf(" Hz: %f", 1 / elapsed.count());
+                printf("\r\n");
+
+                // printRawAGMT( icm_spi.agmt ); // Uncomment this to see the raw
+                // values, taken directly from the agmt structure
+                printScaledAGMT(&icm_spi);  // This function takes into account the scale
+                                            // settings from when the measurement was
+                                            // made to calculate the values with units
+                delay(10);
+            } else {
+                printf("Waiting for data\r\n");
+                delay(500);
+            }
+        }
+    } else {
+        icm_i2c.swReset();
+        if (icm_i2c.status != ICM_20948_Stat_Ok) {
+            printf("Software Reset returned: ");
+            printf("%s\r\n", icm_i2c.statusString());
+        }
+        delay(250);
+
+        // Now wake the sensor up
+        icm_i2c.sleep(false);
+        icm_i2c.lowPower(false);
+
+        // The next few configuration functions accept a bit-mask of sensors for
+        // which the settings should be applied.
+
+        // Set Gyro and Accelerometer to a particular sample mode
+        // options: ICM_20948_Sample_Mode_Continuous
+        //          ICM_20948_Sample_Mode_Cycled
+        icm_i2c.setSampleMode((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr), ICM_20948_Sample_Mode_Continuous);
+        if (icm_i2c.status != ICM_20948_Stat_Ok) {
+            printf("setSampleMode returned: ");
+            printf("%s\r\n", icm_i2c.statusString());
+        }
+        // Set full scale ranges for both acc and gyr
+        ICM_20948_fss_t myFSS;  // This uses a "Full Scale Settings" structure that
+                                // can contain values for all configurable sensors
+
+        myFSS.a = gpm2;  // (ICM_20948_ACCEL_CONFIG_FS_SEL_e)
+                         // gpm2
+                         // gpm4
+                         // gpm8
+                         // gpm16
+
+        myFSS.g = dps1000;  // (ICM_20948_GYRO_CONFIG_1_FS_SEL_e)
+                            // dps250
+                            // dps500
+                            // dps1000
+                            // dps2000
+
+        icm_i2c.setFullScale((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr), myFSS);
+        if (icm_i2c.status != ICM_20948_Stat_Ok) {
+            printf("setFullScale returned: ");
+            printf("%s\r\n", icm_i2c.statusString());
+        }
+
+        // Set up Digital Low-Pass Filter configuration
+        ICM_20948_dlpcfg_t myDLPcfg;     // Similar to FSS, this uses a configuration
+                                         // structure for the desired sensors
+        myDLPcfg.a = acc_d473bw_n499bw;  // (ICM_20948_ACCEL_CONFIG_DLPCFG_e)
+                                         // acc_d246bw_n265bw      - means 3db bandwidth is
+                                         // 246 hz and nyquist bandwidth is 265 hz
+                                         // acc_d111bw4_n136bw acc_d50bw4_n68bw8
+                                         // acc_d23bw9_n34bw4 acc_d11bw5_n17bw acc_d5bw7_n8bw3
+                                         // - means 3 db bandwidth is 5.7 hz and nyquist
+                                         // bandwidth is 8.3 hz acc_d473bw_n499bw
+
+        myDLPcfg.g = gyr_d361bw4_n376bw5;  // (ICM_20948_GYRO_CONFIG_1_DLPCFG_e)
+                                           // gyr_d196bw6_n229bw8
+                                           // gyr_d151bw8_n187bw6
+                                           // gyr_d119bw5_n154bw3
+                                           // gyr_d51bw2_n73bw3
+                                           // gyr_d23bw9_n35bw9
+                                           // gyr_d11bw6_n17bw8
+                                           // gyr_d5bw7_n8bw9
+                                           // gyr_d361bw4_n376bw5
+
+        icm_i2c.setDLPFcfg((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr), myDLPcfg);
+        if (icm_i2c.status != ICM_20948_Stat_Ok) {
+            printf("setDLPcfg returned: ");
+            printf("%s\r\n", icm_i2c.statusString());
+        }
+
+        // Choose whether or not to use DLPF
+        // Here we're also showing another way to access the status values, and that
+        // it is OK to supply individual sensor masks to these functions
+        ICM_20948_Status_e accDLPEnableStat = icm_i2c.enableDLPF(ICM_20948_Internal_Acc, false);
+        ICM_20948_Status_e gyrDLPEnableStat = icm_i2c.enableDLPF(ICM_20948_Internal_Gyr, false);
+        printf("Enable DLPF for Accelerometer returned: ");
+        printf("%s\r\n", icm_i2c.statusString(accDLPEnableStat));
+        printf("Enable DLPF for Gyroscope returned: ");
+        printf("%s\r\n", icm_i2c.statusString(gyrDLPEnableStat));
+
+        printf("Configuration complete!\r\n");
+
+        while (1) {
+            if (icm_i2c.dataReady()) {
+                auto start = std::chrono::system_clock::now();
+                icm_i2c.getAGMT();  // The values are only updated when you call 'getAGMT'
+                auto end = std::chrono::system_clock::now();
+                std::chrono::duration<double> elapsed = end - start;
+                printf(" Hz: %f", 1 / elapsed.count());
+                printf("\r\n");
+
+                // printRawAGMT( icm_i2c.agmt ); // Uncomment this to see the raw
+                // values, taken directly from the agmt structure
+                printScaledAGMT(&icm_i2c);  // This function takes into account the scale
+                                            // settings from when the measurement was
+                                            // made to calculate the values with units
+                delay(10);
+            } else {
+                printf("Waiting for data\r\n");
+                delay(500);
+            }
+        }
     }
-  } else {
-    icm_i2c.swReset();
-    if (icm_i2c.status != ICM_20948_Stat_Ok) {
-      printf("Software Reset returned: ");
-      printf("%s\r\n", icm_i2c.statusString());
-    }
-    delay(250);
-
-    // Now wake the sensor up
-    icm_i2c.sleep(false);
-    icm_i2c.lowPower(false);
-
-    // The next few configuration functions accept a bit-mask of sensors for
-    // which the settings should be applied.
-
-    // Set Gyro and Accelerometer to a particular sample mode
-    // options: ICM_20948_Sample_Mode_Continuous
-    //          ICM_20948_Sample_Mode_Cycled
-    icm_i2c.setSampleMode((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr),
-                          ICM_20948_Sample_Mode_Continuous);
-    if (icm_i2c.status != ICM_20948_Stat_Ok) {
-      printf("setSampleMode returned: ");
-      printf("%s\r\n", icm_i2c.statusString());
-    }
-    // Set full scale ranges for both acc and gyr
-    ICM_20948_fss_t myFSS; // This uses a "Full Scale Settings" structure that
-                           // can contain values for all configurable sensors
-
-    myFSS.a = gpm2; // (ICM_20948_ACCEL_CONFIG_FS_SEL_e)
-                    // gpm2
-                    // gpm4
-                    // gpm8
-                    // gpm16
-
-    myFSS.g = dps1000; // (ICM_20948_GYRO_CONFIG_1_FS_SEL_e)
-                       // dps250
-                       // dps500
-                       // dps1000
-                       // dps2000
-
-    icm_i2c.setFullScale((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr),
-                         myFSS);
-    if (icm_i2c.status != ICM_20948_Stat_Ok) {
-      printf("setFullScale returned: ");
-      printf("%s\r\n", icm_i2c.statusString());
-    }
-
-    // Set up Digital Low-Pass Filter configuration
-    ICM_20948_dlpcfg_t myDLPcfg; // Similar to FSS, this uses a configuration
-                                 // structure for the desired sensors
-    myDLPcfg.a =
-        acc_d473bw_n499bw; // (ICM_20948_ACCEL_CONFIG_DLPCFG_e)
-                           // acc_d246bw_n265bw      - means 3db bandwidth is
-                           // 246 hz and nyquist bandwidth is 265 hz
-                           // acc_d111bw4_n136bw acc_d50bw4_n68bw8
-                           // acc_d23bw9_n34bw4 acc_d11bw5_n17bw acc_d5bw7_n8bw3
-                           // - means 3 db bandwidth is 5.7 hz and nyquist
-                           // bandwidth is 8.3 hz acc_d473bw_n499bw
-
-    myDLPcfg.g = gyr_d361bw4_n376bw5; // (ICM_20948_GYRO_CONFIG_1_DLPCFG_e)
-                                      // gyr_d196bw6_n229bw8
-                                      // gyr_d151bw8_n187bw6
-                                      // gyr_d119bw5_n154bw3
-                                      // gyr_d51bw2_n73bw3
-                                      // gyr_d23bw9_n35bw9
-                                      // gyr_d11bw6_n17bw8
-                                      // gyr_d5bw7_n8bw9
-                                      // gyr_d361bw4_n376bw5
-
-    icm_i2c.setDLPFcfg((ICM_20948_Internal_Acc | ICM_20948_Internal_Gyr),
-                       myDLPcfg);
-    if (icm_i2c.status != ICM_20948_Stat_Ok) {
-      printf("setDLPcfg returned: ");
-      printf("%s\r\n", icm_i2c.statusString());
-    }
-
-    // Choose whether or not to use DLPF
-    // Here we're also showing another way to access the status values, and that
-    // it is OK to supply individual sensor masks to these functions
-    ICM_20948_Status_e accDLPEnableStat =
-        icm_i2c.enableDLPF(ICM_20948_Internal_Acc, false);
-    ICM_20948_Status_e gyrDLPEnableStat =
-        icm_i2c.enableDLPF(ICM_20948_Internal_Gyr, false);
-    printf("Enable DLPF for Accelerometer returned: ");
-    printf("%s\r\n", icm_i2c.statusString(accDLPEnableStat));
-    printf("Enable DLPF for Gyroscope returned: ");
-    printf("%s\r\n", icm_i2c.statusString(gyrDLPEnableStat));
-
-    printf("Configuration complete!\r\n");
-
-    while (1) {
-      if (icm_i2c.dataReady()) {
-        auto start = std::chrono::system_clock::now();
-        icm_i2c
-            .getAGMT(); // The values are only updated when you call 'getAGMT'
-        auto end = std::chrono::system_clock::now();
-        std::chrono::duration<double> elapsed = end - start;
-        printf(" Hz: %f", 1 / elapsed.count());
-        printf("\r\n");
-
-        // printRawAGMT( icm_i2c.agmt ); // Uncomment this to see the raw
-        // values, taken directly from the agmt structure
-        printScaledAGMT(&icm_i2c); // This function takes into account the scale
-                                   // settings from when the measurement was
-                                   // made to calculate the values with units
-        delay(10);
-      } else {
-        printf("Waiting for data\r\n");
-        delay(500);
-      }
-    }
-  }
 }
 
 void printPaddedInt16b(int16_t val) {
-  if (val > 0) {
-    printf(" ");
-    if (val < 10000) {
-      printf("0");
+    if (val > 0) {
+        printf(" ");
+        if (val < 10000) {
+            printf("0");
+        }
+        if (val < 1000) {
+            printf("0");
+        }
+        if (val < 100) {
+            printf("0");
+        }
+        if (val < 10) {
+            printf("0");
+        }
+    } else {
+        printf("-");
+        if (abs(val) < 10000) {
+            printf("0");
+        }
+        if (abs(val) < 1000) {
+            printf("0");
+        }
+        if (abs(val) < 100) {
+            printf("0");
+        }
+        if (abs(val) < 10) {
+            printf("0");
+        }
     }
-    if (val < 1000) {
-      printf("0");
-    }
-    if (val < 100) {
-      printf("0");
-    }
-    if (val < 10) {
-      printf("0");
-    }
-  } else {
-    printf("-");
-    if (abs(val) < 10000) {
-      printf("0");
-    }
-    if (abs(val) < 1000) {
-      printf("0");
-    }
-    if (abs(val) < 100) {
-      printf("0");
-    }
-    if (abs(val) < 10) {
-      printf("0");
-    }
-  }
-  printf("%d", abs(val));
+    printf("%d", abs(val));
 }
 
 void printRawAGMT(ICM_20948_AGMT_t agmt) {
-  printf("RAW. Acc [ ");
-  printPaddedInt16b(agmt.acc.axes.x);
-  printf(", ");
-  printPaddedInt16b(agmt.acc.axes.y);
-  printf(", ");
-  printPaddedInt16b(agmt.acc.axes.z);
-  printf(" ], Gyr [ ");
-  printPaddedInt16b(agmt.gyr.axes.x);
-  printf(", ");
-  printPaddedInt16b(agmt.gyr.axes.y);
-  printf(", ");
-  printPaddedInt16b(agmt.gyr.axes.z);
-  printf(" ]");
-  printf(" ], Mag [ ");
-  printPaddedInt16b(agmt.mag.axes.x);
-  printf(", ");
-  printPaddedInt16b(agmt.mag.axes.y);
-  printf(", ");
-  printPaddedInt16b(agmt.mag.axes.z);
-  printf(" ], Tmp [ ");
-  printPaddedInt16b(agmt.tmp.val);
-  printf(" ]");
-  printf(" ]");
-  printf("\r\n");
+    printf("RAW. Acc [ ");
+    printPaddedInt16b(agmt.acc.axes.x);
+    printf(", ");
+    printPaddedInt16b(agmt.acc.axes.y);
+    printf(", ");
+    printPaddedInt16b(agmt.acc.axes.z);
+    printf(" ], Gyr [ ");
+    printPaddedInt16b(agmt.gyr.axes.x);
+    printf(", ");
+    printPaddedInt16b(agmt.gyr.axes.y);
+    printf(", ");
+    printPaddedInt16b(agmt.gyr.axes.z);
+    printf(" ]");
+    printf(" ], Mag [ ");
+    printPaddedInt16b(agmt.mag.axes.x);
+    printf(", ");
+    printPaddedInt16b(agmt.mag.axes.y);
+    printf(", ");
+    printPaddedInt16b(agmt.mag.axes.z);
+    printf(" ], Tmp [ ");
+    printPaddedInt16b(agmt.tmp.val);
+    printf(" ]");
+    printf(" ]");
+    printf("\r\n");
 }
 
 void printFormattedFloat(float val, uint8_t leading) {
-  float aval = abs(val);
-  if (val < 0) {
-    printf("-");
-  } else {
-    printf(" ");
-  }
-  for (uint8_t indi = 0; indi < leading; indi++) {
-    uint32_t tenpow = 0;
-    if (indi < (leading - 1)) {
-      tenpow = 1;
-    }
-    for (uint8_t c = 0; c < (leading - 1 - indi); c++) {
-      tenpow *= 10;
-    }
-    if (aval < tenpow) {
-      printf("0");
+    float aval = abs(val);
+    if (val < 0) {
+        printf("-");
     } else {
-      break;
+        printf(" ");
     }
-  }
-  if (val < 0) {
-    printf("%f", -val);
-  } else {
-    printf("%f", val);
-  }
+    for (uint8_t indi = 0; indi < leading; indi++) {
+        uint32_t tenpow = 0;
+        if (indi < (leading - 1)) {
+            tenpow = 1;
+        }
+        for (uint8_t c = 0; c < (leading - 1 - indi); c++) {
+            tenpow *= 10;
+        }
+        if (aval < tenpow) {
+            printf("0");
+        } else {
+            break;
+        }
+    }
+    if (val < 0) {
+        printf("%f", -val);
+    } else {
+        printf("%f", val);
+    }
 }
 
-void printScaledAGMT(ICM_20948_SPI *sensor) {
-  printf("Scaled. Acc (mg) [ ");
-  printFormattedFloat(sensor->accX(), 5);
-  printf(", ");
-  printFormattedFloat(sensor->accY(), 5);
-  printf(", ");
-  printFormattedFloat(sensor->accZ(), 5);
-  printf(" ], Gyr (DPS) [ ");
-  printFormattedFloat(sensor->gyrX(), 5);
-  printf(", ");
-  printFormattedFloat(sensor->gyrY(), 5);
-  printf(", ");
-  printFormattedFloat(sensor->gyrZ(), 5);
-  /*
-  printf(" ], Mag (uT) [ ");
-  printFormattedFloat(sensor->magX(), 5, 2);
-  printf(", ");
-  printFormattedFloat(sensor->magY(), 5, 2);
-  printf(", ");
-  printFormattedFloat(sensor->magZ(), 5, 2);
-  */
-  printf(" ], Tmp (C) [ ");
-  printFormattedFloat(sensor->temp(), 5);
-  printf(" ]\r\n");
+void printScaledAGMT(ICM_20948_SPI* sensor) {
+    printf("Scaled. Acc (mg) [ ");
+    printFormattedFloat(sensor->accX(), 5);
+    printf(", ");
+    printFormattedFloat(sensor->accY(), 5);
+    printf(", ");
+    printFormattedFloat(sensor->accZ(), 5);
+    printf(" ], Gyr (DPS) [ ");
+    printFormattedFloat(sensor->gyrX(), 5);
+    printf(", ");
+    printFormattedFloat(sensor->gyrY(), 5);
+    printf(", ");
+    printFormattedFloat(sensor->gyrZ(), 5);
+    /*
+    printf(" ], Mag (uT) [ ");
+    printFormattedFloat(sensor->magX(), 5, 2);
+    printf(", ");
+    printFormattedFloat(sensor->magY(), 5, 2);
+    printf(", ");
+    printFormattedFloat(sensor->magZ(), 5, 2);
+    */
+    printf(" ], Tmp (C) [ ");
+    printFormattedFloat(sensor->temp(), 5);
+    printf(" ]\r\n");
 }
 
-void printScaledAGMT(ICM_20948_I2C *sensor) {
-  printf("Scaled. Acc (mg) [ ");
-  printFormattedFloat(sensor->accX(), 5);
-  printf(", ");
-  printFormattedFloat(sensor->accY(), 5);
-  printf(", ");
-  printFormattedFloat(sensor->accZ(), 5);
-  printf(" ], Gyr (DPS) [ ");
-  printFormattedFloat(sensor->gyrX(), 5);
-  printf(", ");
-  printFormattedFloat(sensor->gyrY(), 5);
-  printf(", ");
-  printFormattedFloat(sensor->gyrZ(), 5);
-  /*
-  printf(" ], Mag (uT) [ ");
-  printFormattedFloat(sensor->magX(), 5, 2);
-  printf(", ");
-  printFormattedFloat(sensor->magY(), 5, 2);
-  printf(", ");
-  printFormattedFloat(sensor->magZ(), 5, 2);
-  */
-  printf(" ], Tmp (C) [ ");
-  printFormattedFloat(sensor->temp(), 5);
-  printf(" ]\r\n");
+void printScaledAGMT(ICM_20948_I2C* sensor) {
+    printf("Scaled. Acc (mg) [ ");
+    printFormattedFloat(sensor->accX(), 5);
+    printf(", ");
+    printFormattedFloat(sensor->accY(), 5);
+    printf(", ");
+    printFormattedFloat(sensor->accZ(), 5);
+    printf(" ], Gyr (DPS) [ ");
+    printFormattedFloat(sensor->gyrX(), 5);
+    printf(", ");
+    printFormattedFloat(sensor->gyrY(), 5);
+    printf(", ");
+    printFormattedFloat(sensor->gyrZ(), 5);
+    /*
+    printf(" ], Mag (uT) [ ");
+    printFormattedFloat(sensor->magX(), 5, 2);
+    printf(", ");
+    printFormattedFloat(sensor->magY(), 5, 2);
+    printf(", ");
+    printFormattedFloat(sensor->magZ(), 5, 2);
+    */
+    printf(" ], Tmp (C) [ ");
+    printFormattedFloat(sensor->temp(), 5);
+    printf(" ]\r\n");
 }

--- a/include/ICM_20948.h
+++ b/include/ICM_20948.h
@@ -34,7 +34,7 @@ extern "C" {
 
 #define ICM_20948_ARD_UNUSED_PIN 0xFF
 
-#define ICM_20948_SPI_DEFAULT_FREQ 4000000
+#define ICM_20948_SPI_DEFAULT_FREQ 4000000U
 #define ICM_20948_SPI_DEFAULT_ORDER MSBFIRST
 #define ICM_20948_SPI_DEFAULT_MODE SPI_MODE0
 
@@ -348,21 +348,11 @@ class ICM_20948_SPI : public ICM_20948 {
 private:
   int _spi_fd;
   uint32_t _speed;
-  uint8_t _bits;
-  struct spi_ioc_transfer _tr; // SPI transfer struct as a member
 
 public:
   ICM_20948_Serif_t _serif;
 
-  ICM_20948_SPI(uint32_t speed, uint8_t bits) {
-    // Initialize the spi_ioc_transfer struct
-    _tr.speed_hz = speed;
-    _tr.bits_per_word = bits;
-    _tr.delay_usecs = 0;
-    _tr.tx_buf = 0;
-    _tr.rx_buf = 0;
-    _tr.len = 0;
-  }
+  ICM_20948_SPI() {}
 
   int spi_transaction(uint8_t *tx, uint8_t *rx, size_t len) {
     struct spi_ioc_transfer xfer;
@@ -371,9 +361,9 @@ public:
     xfer.tx_buf = (unsigned long)tx;
     xfer.rx_buf = (unsigned long)rx;
     xfer.len = len;
-    xfer.speed_hz = 4000000; // TODO : adjust this value as needed
+    xfer.speed_hz = _speed;
     xfer.bits_per_word = 8;
-    xfer.delay_usecs = 0; // TODO : adjust delay if needed
+    xfer.delay_usecs = 0;
 
     int ret = ioctl(_spi_fd, SPI_IOC_MESSAGE(1), &xfer);
     if (ret < 0) {
@@ -384,8 +374,7 @@ public:
     return 0;
   }
 
-  virtual ICM_20948_Status_e begin(const char *device = "/dev/spidev2.0",
-                                   uint32_t speed = ICM_20948_SPI_DEFAULT_FREQ);
+  virtual ICM_20948_Status_e begin(const char *device, uint32_t speed);
 };
 
 #endif /* _ICM_20948_H_ */

--- a/src/ICM_20948.cpp
+++ b/src/ICM_20948.cpp
@@ -1989,6 +1989,8 @@ ICM_20948_Status_e ICM_20948_read_I2C(uint8_t reg, uint8_t *buff, uint32_t len,
 }
 
 ICM_20948_Status_e ICM_20948_SPI::begin(const char *device, uint32_t speed) {
+  _speed = speed;
+  
   _spi_fd = open(device, O_RDWR);
   if (_spi_fd < 0) {
     perror("Failed to open SPI device");
@@ -1997,7 +1999,6 @@ ICM_20948_Status_e ICM_20948_SPI::begin(const char *device, uint32_t speed) {
 
   uint8_t mode = SPI_MODE_0;
   uint8_t bits = 8;
-  // uint32_t speed = 1000000; // 1 MHz
   char lsbfirst = 0;
 
   if (ioctl(_spi_fd, SPI_IOC_RD_MODE, &mode) < 0) {
@@ -2076,7 +2077,7 @@ ICM_20948_Status_e ICM_20948_SPI::begin(const char *device, uint32_t speed) {
   // startupDefault(false) manually if required.
   status = startupDefault(_device._dmp_firmware_available);
   if (status != ICM_20948_Stat_Ok) {
-    debugPrint(("ICM_20948_I2C::begin: startupDefault returned: "));
+    debugPrint(("ICM_20948_SPI::begin: startupDefault returned: "));
     debugPrintStatus(status);
     debugPrintln((""));
   }


### PR DESCRIPTION
On Orin Nano, while running the spi example code fails with stack smashing. to avoid it, I added `-fstack-protector` to compile options.

Note that, eventually, we might have to rewrite the icm20948 lib from scratch.